### PR TITLE
fixed fs for newer version of fs/node

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function (options, accessDenied) {
 		
 		// Check that geolite2 exists (fs.exists is deprecated)
 		var geo2 = fs.openSync(options.geolite2, "r");
-		fs.close(geo2);
+		fs.closeSync(geo2);
 		
 		options.blocked = options.blocked || [];
 		options.blockedCountries = options.blockedCountries || [];


### PR DESCRIPTION
On newer versions of FS, they require async functions to have a callback.
Since `fs.close` is an async, it throws an error when you run the code (and crashes everything).

[fs.close](https://nodejs.org/api/fs.html#fs_fs_close_fd_callback)
[fs.closeSync](https://nodejs.org/api/fs.html#fs_fs_closesync_fd)
